### PR TITLE
fix: Javascript es6 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,196 +18,197 @@ stages:
 
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      compiler: clang
-      jdk: openjdk8
-      env:
-        - TARGET=cpp
-        - CXX=g++-5
-        - GROUP=LEXER
-      stage: main-test
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - g++-5
-            - uuid-dev
-            - clang-3.7
-    - os: linux
-      dist: trusty
-      compiler: clang
-      jdk: openjdk8
-      env:
-        - TARGET=cpp
-        - CXX=g++-5
-        - GROUP=PARSER
-      stage: main-test
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - g++-5
-            - uuid-dev
-            - clang-3.7
-    - os: linux
-      dist: trusty
-      compiler: clang
-      jdk: openjdk8
-      env:
-        - TARGET=cpp
-        - CXX=g++-5
-        - GROUP=RECURSION
-      stage: main-test
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - g++-5
-            - uuid-dev
-            - clang-3.7
-    - os: osx
-      compiler: clang
-      osx_image: xcode10.2
-      env:
-        - TARGET=cpp
-        - GROUP=LEXER
-      stage: extended-test
-    - os: osx
-      compiler: clang
-      osx_image: xcode10.2
-      env:
-        - TARGET=cpp
-        - GROUP=PARSER
-      stage: extended-test
-    - os: osx
-      compiler: clang
-      osx_image: xcode10.2
-      env:
-        - TARGET=cpp
-        - GROUP=RECURSION
-      stage: extended-test
-    - os: osx
-      compiler: clang
-      osx_image: xcode10.2
-      env:
-        - TARGET=swift
-        - GROUP=LEXER
-      stage: main-test
-    - os: osx
-      compiler: clang
-      osx_image: xcode10.2
-      env:
-        - TARGET=swift
-        - GROUP=PARSER
-      stage: main-test
-    - os: osx
-      compiler: clang
-      osx_image: xcode10.2
-      env:
-        - TARGET=swift
-        - GROUP=RECURSION
-      stage: main-test
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env:
-       - TARGET=swift
-       - GROUP=ALL
-      stage: extended-test
-    - os: osx
-      osx_image: xcode10.2
-      env:
-        - TARGET=dotnet
-        - GROUP=LEXER
-      stage: extended-test
-    - os: osx
-      osx_image: xcode10.2
-      env:
-        - TARGET=dotnet
-        - GROUP=PARSER
-      stage: extended-test
-    - os: osx
-      osx_image: xcode10.2
-      env:
-        - TARGET=dotnet
-        - GROUP=RECURSION
-      stage: extended-test
-    - os: linux
-      dist: trusty
-      jdk: openjdk7
-      env: TARGET=java
-      stage: extended-test
-    - os: linux
-      jdk: openjdk8
-      env: TARGET=java
-      stage: smoke-test
-    - os: linux
-      jdk: openjdk8
-      env: TARGET=csharp
-      stage: main-test
-    - os: linux
-      jdk: openjdk8
-      env: TARGET=dart
-      stage: main-test
-    - os: linux
-      language: php
-      php:
-        - 7.2
-      jdk: openjdk8
-      env: TARGET=php
-      stage: main-test
-    - os: linux
-      jdk: openjdk8
-      dist: trusty
-      env:
-        - TARGET=dotnet
-        - GROUP=LEXER
-      stage: extended-test
-    - os: linux
-      jdk: openjdk8
-      dist: trusty
-      env:
-        - TARGET=dotnet
-        - GROUP=PARSER
-      stage: extended-test
-    - os: linux
-      jdk: openjdk8
-      dist: trusty
-      env:
-        - TARGET=dotnet
-        - GROUP=RECURSION
-      stage: extended-test
-    - os: linux
-      jdk: openjdk8
-      env: TARGET=python2
-      stage: main-test
-    - os: linux
-      jdk: openjdk8
-      env: TARGET=python3
-      addons:
-        apt:
-          sources:
-            - deadsnakes # source required so it finds the package definition below
-          packages:
-            - python3.7
-      stage: main-test
+# TODO: rollback
+#    - os: linux
+#      dist: trusty
+#      compiler: clang
+#      jdk: openjdk8
+#      env:
+#        - TARGET=cpp
+#        - CXX=g++-5
+#        - GROUP=LEXER
+#      stage: main-test
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - llvm-toolchain-precise-3.7
+#          packages:
+#            - g++-5
+#            - uuid-dev
+#            - clang-3.7
+#    - os: linux
+#      dist: trusty
+#      compiler: clang
+#      jdk: openjdk8
+#      env:
+#        - TARGET=cpp
+#        - CXX=g++-5
+#        - GROUP=PARSER
+#      stage: main-test
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - llvm-toolchain-precise-3.7
+#          packages:
+#            - g++-5
+#            - uuid-dev
+#            - clang-3.7
+#    - os: linux
+#      dist: trusty
+#      compiler: clang
+#      jdk: openjdk8
+#      env:
+#        - TARGET=cpp
+#        - CXX=g++-5
+#        - GROUP=RECURSION
+#      stage: main-test
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - llvm-toolchain-precise-3.7
+#          packages:
+#            - g++-5
+#            - uuid-dev
+#            - clang-3.7
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=cpp
+#        - GROUP=LEXER
+#      stage: extended-test
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=cpp
+#        - GROUP=PARSER
+#      stage: extended-test
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=cpp
+#        - GROUP=RECURSION
+#      stage: extended-test
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=swift
+#        - GROUP=LEXER
+#      stage: main-test
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=swift
+#        - GROUP=PARSER
+#      stage: main-test
+#    - os: osx
+#      compiler: clang
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=swift
+#        - GROUP=RECURSION
+#      stage: main-test
+#    - os: linux
+#      dist: xenial
+#      compiler: clang
+#      env:
+#       - TARGET=swift
+#       - GROUP=ALL
+#      stage: extended-test
+#    - os: osx
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=dotnet
+#        - GROUP=LEXER
+#      stage: extended-test
+#    - os: osx
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=dotnet
+#        - GROUP=PARSER
+#      stage: extended-test
+#    - os: osx
+#      osx_image: xcode10.2
+#      env:
+#        - TARGET=dotnet
+#        - GROUP=RECURSION
+#      stage: extended-test
+#    - os: linux
+#      dist: trusty
+#      jdk: openjdk7
+#      env: TARGET=java
+#      stage: extended-test
+#    - os: linux
+#      jdk: openjdk8
+#      env: TARGET=java
+#      stage: smoke-test
+#    - os: linux
+#      jdk: openjdk8
+#      env: TARGET=csharp
+#      stage: main-test
+#    - os: linux
+#      jdk: openjdk8
+#      env: TARGET=dart
+#      stage: main-test
+#    - os: linux
+#      language: php
+#      php:
+#        - 7.2
+#      jdk: openjdk8
+#      env: TARGET=php
+#      stage: main-test
+#    - os: linux
+#      jdk: openjdk8
+#      dist: trusty
+#      env:
+#        - TARGET=dotnet
+#        - GROUP=LEXER
+#      stage: extended-test
+#    - os: linux
+#      jdk: openjdk8
+#      dist: trusty
+#      env:
+#        - TARGET=dotnet
+#        - GROUP=PARSER
+#      stage: extended-test
+#    - os: linux
+#      jdk: openjdk8
+#      dist: trusty
+#      env:
+#        - TARGET=dotnet
+#        - GROUP=RECURSION
+#      stage: extended-test
+#    - os: linux
+#      jdk: openjdk8
+#      env: TARGET=python2
+#      stage: main-test
+#    - os: linux
+#      jdk: openjdk8
+#      env: TARGET=python3
+#      addons:
+#        apt:
+#          sources:
+#            - deadsnakes # source required so it finds the package definition below
+#          packages:
+#            - python3.7
+#      stage: main-test
     - os: linux
       dist: trusty
       jdk: openjdk8
       env: TARGET=javascript
       stage: main-test
-    - os: linux
-      dist: trusty
-      jdk: openjdk8
-      env: TARGET=go
-      stage: main-test
+#    - os: linux
+#      dist: trusty
+#      jdk: openjdk8
+#      env: TARGET=go
+#      stage: main-test
 
 before_install:
   - f="./.travis/before-install-$TRAVIS_OS_NAME-$TARGET.sh"; ! [ -x "$f" ] || "$f"

--- a/.travis.yml
+++ b/.travis.yml
@@ -202,6 +202,7 @@ matrix:
     - os: linux
       dist: trusty
       jdk: openjdk8
+      language: node_js
       node_js:
         - 14
       env: TARGET=javascript

--- a/.travis.yml
+++ b/.travis.yml
@@ -202,11 +202,10 @@ matrix:
     - os: linux
       dist: trusty
       jdk: openjdk8
-      language: node_js
-      node_js:
-        - 14
       env: TARGET=javascript
       stage: main-test
+      before_install:
+        - nvm install 14
 #    - os: linux
 #      dist: trusty
 #      jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,199 +18,198 @@ stages:
 
 matrix:
   include:
-# TODO: rollback
-#    - os: linux
-#      dist: trusty
-#      compiler: clang
-#      jdk: openjdk8
-#      env:
-#        - TARGET=cpp
-#        - CXX=g++-5
-#        - GROUP=LEXER
-#      stage: main-test
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.7
-#          packages:
-#            - g++-5
-#            - uuid-dev
-#            - clang-3.7
-#    - os: linux
-#      dist: trusty
-#      compiler: clang
-#      jdk: openjdk8
-#      env:
-#        - TARGET=cpp
-#        - CXX=g++-5
-#        - GROUP=PARSER
-#      stage: main-test
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.7
-#          packages:
-#            - g++-5
-#            - uuid-dev
-#            - clang-3.7
-#    - os: linux
-#      dist: trusty
-#      compiler: clang
-#      jdk: openjdk8
-#      env:
-#        - TARGET=cpp
-#        - CXX=g++-5
-#        - GROUP=RECURSION
-#      stage: main-test
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.7
-#          packages:
-#            - g++-5
-#            - uuid-dev
-#            - clang-3.7
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=cpp
-#        - GROUP=LEXER
-#      stage: extended-test
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=cpp
-#        - GROUP=PARSER
-#      stage: extended-test
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=cpp
-#        - GROUP=RECURSION
-#      stage: extended-test
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=swift
-#        - GROUP=LEXER
-#      stage: main-test
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=swift
-#        - GROUP=PARSER
-#      stage: main-test
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=swift
-#        - GROUP=RECURSION
-#      stage: main-test
-#    - os: linux
-#      dist: xenial
-#      compiler: clang
-#      env:
-#       - TARGET=swift
-#       - GROUP=ALL
-#      stage: extended-test
-#    - os: osx
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=dotnet
-#        - GROUP=LEXER
-#      stage: extended-test
-#    - os: osx
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=dotnet
-#        - GROUP=PARSER
-#      stage: extended-test
-#    - os: osx
-#      osx_image: xcode10.2
-#      env:
-#        - TARGET=dotnet
-#        - GROUP=RECURSION
-#      stage: extended-test
-#    - os: linux
-#      dist: trusty
-#      jdk: openjdk7
-#      env: TARGET=java
-#      stage: extended-test
-#    - os: linux
-#      jdk: openjdk8
-#      env: TARGET=java
-#      stage: smoke-test
-#    - os: linux
-#      jdk: openjdk8
-#      env: TARGET=csharp
-#      stage: main-test
-#    - os: linux
-#      jdk: openjdk8
-#      env: TARGET=dart
-#      stage: main-test
-#    - os: linux
-#      language: php
-#      php:
-#        - 7.2
-#      jdk: openjdk8
-#      env: TARGET=php
-#      stage: main-test
-#    - os: linux
-#      jdk: openjdk8
-#      dist: trusty
-#      env:
-#        - TARGET=dotnet
-#        - GROUP=LEXER
-#      stage: extended-test
-#    - os: linux
-#      jdk: openjdk8
-#      dist: trusty
-#      env:
-#        - TARGET=dotnet
-#        - GROUP=PARSER
-#      stage: extended-test
-#    - os: linux
-#      jdk: openjdk8
-#      dist: trusty
-#      env:
-#        - TARGET=dotnet
-#        - GROUP=RECURSION
-#      stage: extended-test
-#    - os: linux
-#      jdk: openjdk8
-#      env: TARGET=python2
-#      stage: main-test
-#    - os: linux
-#      jdk: openjdk8
-#      env: TARGET=python3
-#      addons:
-#        apt:
-#          sources:
-#            - deadsnakes # source required so it finds the package definition below
-#          packages:
-#            - python3.7
-#      stage: main-test
+    - os: linux
+      dist: trusty
+      compiler: clang
+      jdk: openjdk8
+      env:
+        - TARGET=cpp
+        - CXX=g++-5
+        - GROUP=LEXER
+      stage: main-test
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - g++-5
+            - uuid-dev
+            - clang-3.7
+    - os: linux
+      dist: trusty
+      compiler: clang
+      jdk: openjdk8
+      env:
+        - TARGET=cpp
+        - CXX=g++-5
+        - GROUP=PARSER
+      stage: main-test
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - g++-5
+            - uuid-dev
+            - clang-3.7
+    - os: linux
+      dist: trusty
+      compiler: clang
+      jdk: openjdk8
+      env:
+        - TARGET=cpp
+        - CXX=g++-5
+        - GROUP=RECURSION
+      stage: main-test
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - g++-5
+            - uuid-dev
+            - clang-3.7
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+      env:
+        - TARGET=cpp
+        - GROUP=LEXER
+      stage: extended-test
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+      env:
+        - TARGET=cpp
+        - GROUP=PARSER
+      stage: extended-test
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+      env:
+        - TARGET=cpp
+        - GROUP=RECURSION
+      stage: extended-test
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+      env:
+        - TARGET=swift
+        - GROUP=LEXER
+      stage: main-test
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+      env:
+        - TARGET=swift
+        - GROUP=PARSER
+      stage: main-test
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+      env:
+        - TARGET=swift
+        - GROUP=RECURSION
+      stage: main-test
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env:
+       - TARGET=swift
+       - GROUP=ALL
+      stage: extended-test
+    - os: osx
+      osx_image: xcode10.2
+      env:
+        - TARGET=dotnet
+        - GROUP=LEXER
+      stage: extended-test
+    - os: osx
+      osx_image: xcode10.2
+      env:
+        - TARGET=dotnet
+        - GROUP=PARSER
+      stage: extended-test
+    - os: osx
+      osx_image: xcode10.2
+      env:
+        - TARGET=dotnet
+        - GROUP=RECURSION
+      stage: extended-test
+    - os: linux
+      dist: trusty
+      jdk: openjdk7
+      env: TARGET=java
+      stage: extended-test
+    - os: linux
+      jdk: openjdk8
+      env: TARGET=java
+      stage: smoke-test
+    - os: linux
+      jdk: openjdk8
+      env: TARGET=csharp
+      stage: main-test
+    - os: linux
+      jdk: openjdk8
+      env: TARGET=dart
+      stage: main-test
+    - os: linux
+      language: php
+      php:
+        - 7.2
+      jdk: openjdk8
+      env: TARGET=php
+      stage: main-test
+    - os: linux
+      jdk: openjdk8
+      dist: trusty
+      env:
+        - TARGET=dotnet
+        - GROUP=LEXER
+      stage: extended-test
+    - os: linux
+      jdk: openjdk8
+      dist: trusty
+      env:
+        - TARGET=dotnet
+        - GROUP=PARSER
+      stage: extended-test
+    - os: linux
+      jdk: openjdk8
+      dist: trusty
+      env:
+        - TARGET=dotnet
+        - GROUP=RECURSION
+      stage: extended-test
+    - os: linux
+      jdk: openjdk8
+      env: TARGET=python2
+      stage: main-test
+    - os: linux
+      jdk: openjdk8
+      env: TARGET=python3
+      addons:
+        apt:
+          sources:
+            - deadsnakes # source required so it finds the package definition below
+          packages:
+            - python3.7
+      stage: main-test
     - os: linux
       dist: trusty
       jdk: openjdk8
       env: TARGET=javascript
       stage: main-test
       before_install:
-        - nvm install 14
-#    - os: linux
-#      dist: trusty
-#      jdk: openjdk8
-#      env: TARGET=go
-#      stage: main-test
+        - nvm install 14 # otherwise it runs by default on node 8
+    - os: linux
+      dist: trusty
+      jdk: openjdk8
+      env: TARGET=go
+      stage: main-test
 
 before_install:
   - f="./.travis/before-install-$TRAVIS_OS_NAME-$TARGET.sh"; ! [ -x "$f" ] || "$f"

--- a/.travis.yml
+++ b/.travis.yml
@@ -202,6 +202,8 @@ matrix:
     - os: linux
       dist: trusty
       jdk: openjdk8
+      node_js:
+        - 14
       env: TARGET=javascript
       stage: main-test
 #    - os: linux

--- a/.travis/before-install-linux-javascript.sh
+++ b/.travis/before-install-linux-javascript.sh
@@ -3,6 +3,4 @@
 set -euo pipefail
 
 # use v14 and check
-nvm install 14
-nvm use 14
 node --version

--- a/.travis/run-tests-javascript.sh
+++ b/.travis/run-tests-javascript.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-cd target/classes/JavaScript
-
-npm install
-
-cd ../../..
-
 set -euo pipefail
 
 mvn -q -Dparallel=methods -DthreadCount=1 -Dtest=javascript.* test


### PR DESCRIPTION
it turns out that the culprit was in fact travis-ci not using the proper node version. Adding the snippet directly to the job did the trick.